### PR TITLE
add Get to refs to gather info about an existing ref. Convenience met…

### DIFF
--- a/refs.go
+++ b/refs.go
@@ -46,3 +46,23 @@ func (api *RefsAPI) Create(ref, sha string) (*CreateRefResponse, error) {
 
 	return &response, nil
 }
+
+// Get information about a ref. `ref` must be formatted as heads/master, not just master
+// https://developer.github.com/v3/git/refs/#get-a-reference
+func (api *RefsAPI) Get(ref string) (*CreateRefResponse, error) {
+	url := api.getURL("/repos/:owner/:repo/git/refs/")
+
+	resp, err := api.httpGet(url + ref)
+	if err != nil {
+		return nil, err
+	}
+
+	var refInfo CreateRefResponse
+
+	j := json.NewDecoder(resp.Body)
+	if err = j.Decode(&refInfo); err != nil {
+		return nil, err
+	}
+
+	return &refInfo, nil
+}


### PR DESCRIPTION
@judwhite 

needed to cut a new branch, as creating a ref requires the sha of the base ref.